### PR TITLE
Change `LimitCheker`'s spent amount updates handling

### DIFF
--- a/contracts/LimitsChecker.sol
+++ b/contracts/LimitsChecker.sol
@@ -191,11 +191,6 @@ contract LimitsChecker is AccessControl {
         currentPeriodEndTimestamp = uint128(currentPeriodEndTimestampLocal);
         limit = uint128(_limit);
 
-        /// set spent to _limit if it's greater to avoid math underflow error
-        if (spentAmount > _limit) {
-            spentAmount = uint128(_limit);
-        }
-
         emit LimitsParametersChanged(_limit, _periodDurationMonths);
     }
 
@@ -273,7 +268,7 @@ contract LimitsChecker is AccessControl {
         pure
         returns (uint256)
     {
-        return _limit - _spentAmount;
+        return _spentAmount < _limit ? _limit - _spentAmount : 0;
     }
 
     function _validatePeriodDurationMonths(uint256 _periodDurationMonths) internal pure {

--- a/contracts/LimitsChecker.sol
+++ b/contracts/LimitsChecker.sol
@@ -42,6 +42,7 @@ contract LimitsChecker is AccessControl {
     );
     event CurrentPeriodAdvanced(uint256 indexed _periodStartTimestamp);
     event BokkyPooBahsDateTimeContractChanged(address indexed _newAddress);
+    event SpentAmountChanged(uint256 _newSpentAmount);
 
     // -------------
     // ERRORS
@@ -51,6 +52,8 @@ contract LimitsChecker is AccessControl {
     string private constant ERROR_TOO_LARGE_LIMIT = "TOO_LARGE_LIMIT";
     string private constant ERROR_SAME_DATE_TIME_CONTRACT_ADDRESS =
         "SAME_DATE_TIME_CONTRACT_ADDRESS";
+    string private constant ERROR_SPENT_AMOUNT_EXCEEDS_LIMIT = "ERROR_SPENT_AMOUNT_EXCEEDS_LIMIT";
+
     // -------------
     // ROLES
     // -------------
@@ -236,6 +239,17 @@ contract LimitsChecker is AccessControl {
 
         bokkyPooBahsDateTimeContract = IBokkyPooBahsDateTimeContract(_bokkyPooBahsDateTimeContract);
         emit BokkyPooBahsDateTimeContractChanged(_bokkyPooBahsDateTimeContract);
+    }
+
+    /// @notice Allows setting the amount of spent tokens in the current period manually
+    /// @param _newSpentAmount New value for the amount of spent tokens in the current period
+    function unsafeSetSpentAmount(uint256 _newSpentAmount) external onlyRole(SET_PARAMETERS_ROLE) {
+        require(_newSpentAmount <= limit, ERROR_SPENT_AMOUNT_EXCEEDS_LIMIT);
+
+        if (spentAmount != _newSpentAmount) {
+            spentAmount = uint128(_newSpentAmount);
+            emit SpentAmountChanged(_newSpentAmount);
+        }
     }
 
     // ------------------

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -593,7 +593,7 @@ def allowed_recipients_registry(
         [],
         [],
         allowed_recipients_default_params.spent_amount,
-        False,
+        True,
         {"from": deployer},
     )
 

--- a/tests/test_allowed_recipients_registry.py
+++ b/tests/test_allowed_recipients_registry.py
@@ -852,12 +852,13 @@ def test_spendable_amount_if_limit_decreased_below_spent_amount(limits_checker):
 
     new_period_limit = spending - 1
     new_spendable = 0
-    # NB!: already spent amount decreased to the new limit
-    new_spending = new_period_limit
+
     limits_checker.setLimitParameters(
         new_period_limit, period_duration, {"from": set_parameters_role_holder}
     )
-    assert limits_checker.getPeriodState()["_alreadySpentAmount"] == new_spending
+
+    # the already spent amount stays the same after the limit update
+    assert limits_checker.getPeriodState()["_alreadySpentAmount"] == spending
     assert limits_checker.getPeriodState()["_spendableBalanceInPeriod"] == new_spendable
     assert limits_checker.spendableBalance() == new_spendable
 
@@ -890,12 +891,13 @@ def test_spendable_amount_if_limit_decreased_not_below_spent_amount(limits_check
 
     new_period_limit = 2 * spending
     new_spendable = new_period_limit - spending
-    # NB!: already spent amount decreased to the new limit
-    new_spending = spending
+
     limits_checker.setLimitParameters(
         new_period_limit, period_duration, {"from": set_parameters_role_holder}
     )
-    assert limits_checker.getPeriodState()["_alreadySpentAmount"] == new_spending
+
+    # the already spent amount stays the same after the limit update
+    assert limits_checker.getPeriodState()["_alreadySpentAmount"] == spending
     assert limits_checker.getPeriodState()["_spendableBalanceInPeriod"] == new_spendable
     assert limits_checker.spendableBalance() == new_spendable
 


### PR DESCRIPTION
This PR applies next changes to the `LimitChecker` contract:
- Adds a method to unsafe set spent limit
- Updates method `setLimitParameters` to not change the spent amount on limit params update