### PR TITLE
Hoodi EasyTrack deployment

### DIFF
--- a/deployed-csm-hoodi.json
+++ b/deployed-csm-hoodi.json
@@ -1,0 +1,10 @@
+{
+  "CSMSettleElStealingPenalty": {
+    "contract": "CSMSettleElStealingPenalty",
+    "address": "0x5c0af5b9f96921d3F61503e1006CF0ab9867279E",
+    "constructorArgs": [
+      "0x4af43ee34a6fcd1feca1e1f832124c763561da53",
+      "0x79CEf36D84743222f37765204Bec41E92a93E59d"
+    ]
+  }
+}

--- a/deployed-hoodi.json
+++ b/deployed-hoodi.json
@@ -1,0 +1,28 @@
+{
+  "EasyTrack": {
+    "contract": "EasyTrack",
+    "address": "0x284D91a7D47850d21A6DEaaC6E538AC7E5E6fc2a",
+    "constructorArgs": [
+      "0xEf2573966D009CcEA0Fc74451dee2193564198dc",
+      "0xBE2fD5a6Ce6460EB5e9aCC5d486697aE6402fdd2",
+      600,
+      24,
+      500
+    ]
+  },
+  "EVMScriptExecutor": {
+    "contract": "EVMScriptExecutor",
+    "address": "0x79a20FD0FA36453B2F45eAbab19bfef43575Ba9E",
+    "constructorArgs": [
+      "0xfB3cB48d81eC8c7f2013a8dc9fA46D2D48112c3A",
+      "0x284D91a7D47850d21A6DEaaC6E538AC7E5E6fc2a"
+    ]
+  },
+  "IncreaseNodeOperatorStakingLimit": {
+    "contract": "IncreaseNodeOperatorStakingLimit",
+    "address": "0x0f121e4069e17a2Dc5bAbF39d769313a1e20f323",
+    "constructorArgs": [
+      "0x5cDbE1590c083b5A2A64427fAA63A7cfDB91FbB5"
+    ]
+  }
+}

--- a/network-config.yaml
+++ b/network-config.yaml
@@ -9,6 +9,15 @@ live:
     multicall2: "0xcA11bde05977b3631167028862bE2a173976CA11"
     name: Holesky (Infura)
     provider: infura
+  - chainid: 560048
+    # TODO: replace with etherscan explorer when deployed
+    explorer: https://hoodi.cloud.blockscout.com/api/v2
+    host: $HOODI_RPC_URL
+    id: hoodi
+    # New backward-compatible multicall contract. multicall2 is missing on Holesky. See https://github.com/mds1/multicall
+    #multicall2: TODO: deploy multicall on hoodi at put address here
+    name: Hoodi (Infura)
+    provider: infura
 development:
   - cmd: ./ganache.sh
     cmd_settings:
@@ -46,3 +55,15 @@ development:
     host: http://127.0.0.1
     id: holesky-fork
     name: holesky-fork
+  - cmd: ./ganache.sh
+    cmd_settings:
+      accounts: 10
+      chain_id: 560048
+      evm_version: shanghai
+      fork: $HOODI_RPC_URL
+      gas_limit: 30000000
+      mnemonic: brownie
+      port: 8545
+    host: http://127.0.0.1
+    id: hoodi-fork
+    name: hoodi-fork

--- a/utils/csm.py
+++ b/utils/csm.py
@@ -13,6 +13,10 @@ def addresses(network=DEFAULT_NETWORK):
         return CSMAddressesSetup(
             module="0x4562c3e63c2e586cD1651B958C22F88135aCAd4f",
         )
+    if network == "hoodi" or network == "hoodi-fork":
+        return CSMAddressesSetup(
+            module="0x79CEf36D84743222f37765204Bec41E92a93E59d"
+        )
     raise NameError(
         f"Unknown network '{network}'. Supported networks: mainnet, mainnet-fork, holesky, holesky-fork"
     )

--- a/utils/lido.py
+++ b/utils/lido.py
@@ -1,5 +1,5 @@
 import brownie
-from utils import evm_script as evm_script_utils
+from utils import evm_script as evm_script_utils, config
 
 DEFAULT_NETWORK = "mainnet"
 
@@ -59,6 +59,24 @@ def addresses(network=DEFAULT_NETWORK):
             staking_router="0xa3Dbd317E53D363176359E10948BA0b1c0A4c820",
             locator="0x1eDf09b5023DC86737b59dE68a8130De878984f5",
         )
+    if network == "hoodi" or network == "hoodi-fork":
+        return LidoAddressesSetup(
+            aragon=AragonSetup(
+                acl="0x78780e70Eae33e2935814a327f7dB6c01136cc62",
+                agent="0x0534aA41907c9631fae990960bCC72d75fA7cfeD",
+                voting="0x49B3512c44891bef83F8967d075121Bd1b07a01B",
+                finance="0x254Ae22bEEba64127F0e59fe8593082F3cd13f6b",
+                gov_token="0xEf2573966D009CcEA0Fc74451dee2193564198dc",
+                calls_script="0xfB3cB48d81eC8c7f2013a8dc9fA46D2D48112c3A",
+                token_manager="0x8ab4a56721Ad8e68c6Ad86F9D9929782A78E39E5",
+                kernel="0xA48DF029Fd2e5FCECB3886c5c2F60e3625A1E87d",
+            ),
+            steth="0x3508A952176b3c15387C97BE809eaffB1982176a",
+            node_operators_registry="0x5cDbE1590c083b5A2A64427fAA63A7cfDB91FbB5",
+            simple_dvt="0x0B5236BECA68004DB89434462DfC3BB074d2c830",
+            staking_router="0xCc820558B39ee15C7C45B59390B503b83fb499A8",
+            locator="0xe2EF9536DAAAEBFf5b1c130957AB3E80056b06D8",
+        )
     raise NameError(
         f"""Unknown network "{network}". Supported networks: mainnet, mainnet-fork goerli, goerli-fork, holesky, holesky-fork"""
     )
@@ -106,6 +124,8 @@ class LidoContractsSetup:
     def create_voting(self, evm_script, description, tx_params=None):
         voting = self.aragon.voting
 
+        config.set_balance_in_wei(self.aragon.agent.address, 100 * 10**18)
+
         voting_tx = self.aragon.token_manager.forward(
             evm_script_utils.encode_call_script(
                 [
@@ -115,7 +135,7 @@ class LidoContractsSetup:
                     )
                 ]
             ),
-            tx_params or {"from": self.aragon.agent},
+            tx_params or {"from": self.aragon.agent, "priority_fee": "2 gwei"},
         )
         return voting_tx.events["StartVote"]["voteId"], voting_tx
 
@@ -124,19 +144,19 @@ class LidoContractsSetup:
         if voting.getVote(voting_id)["executed"]:
             print(f"Voting {voting_id} already executed")
             return
-        ldo_holders = [self.aragon.agent]
+        ldo_holders = [self.aragon.agent.address]
         for holder_addr in ldo_holders:
             if not voting.canVote(voting_id, holder_addr):
                 print(f"{holder_addr} can't vote in voting {voting_id}")
                 continue
-            brownie.accounts[0].transfer(holder_addr, "0.1 ether")
+            config.set_balance_in_wei(holder_addr, 10**18)
             account = brownie.accounts.at(holder_addr, force=True)
-            voting.vote(voting_id, True, False, {"from": account})
+            voting.vote(voting_id, True, False, {"from": account, "priority_fee": "2 gwei"})
 
         brownie.chain.sleep(3 * 60 * 60 * 24)
         brownie.chain.mine()
         assert voting.canExecute(voting_id)
-        voting.executeVote(voting_id, {"from": brownie.accounts[0]})
+        voting.executeVote(voting_id, {"from": brownie.accounts[0], "priority_fee": "2 gwei"})
 
 
 class LidoAddressesSetup:


### PR DESCRIPTION
This PR adds support for the Hoodi testnet and provides the deployed addresses of the EasyTrack instance and factories. The initial configuration values for EasyTrack used during deployment:

- `MAX_MOTIONS_LIMIT` - 255
- `MAX_OBJECTIONS_THRESHOLD` = 10_00 bps (10.00 %)
- `MIN_MOTION_DURATION` = 60 seconds
- `motionDuration` = 10 minutes
- `motionsCountLimit` = 24
- `objectionsThreshold` = 500

**Deployed Addresses**
- EasyTrack: [`0x284D91a7D47850d21A6DEaaC6E538AC7E5E6fc2a`](https://hoodi.cloud.blockscout.com/address/0x284D91a7D47850d21A6DEaaC6E538AC7E5E6fc2a)
- EVMScriptExecutor: [`0x79a20FD0FA36453B2F45eAbab19bfef43575Ba9E`](https://hoodi.cloud.blockscout.com/address/0x79a20FD0FA36453B2F45eAbab19bfef43575Ba9E)
- IncreaseNodeOperatorStakingLimit: [`0x0f121e4069e17a2Dc5bAbF39d769313a1e20f323`](https://hoodi.cloud.blockscout.com/address/0x0f121e4069e17a2Dc5bAbF39d769313a1e20f323)
- CSMSettleElStealingPenalty: [`0x5c0af5b9f96921d3F61503e1006CF0ab9867279E`](https://hoodi.cloud.blockscout.com/address/0x5c0af5b9f96921d3F61503e1006CF0ab9867279E)
