### PR TITLE
fix: remove redundant isPendingDisconnect check

### DIFF
--- a/contracts/EVMScriptFactories/vaultFactories/VaultsAdapter.sol
+++ b/contracts/EVMScriptFactories/vaultFactories/VaultsAdapter.sol
@@ -146,9 +146,7 @@ contract VaultsAdapter is TrustedCaller {
 
         IVaultHub vaultHub = IVaultHub(lidoLocator.vaultHub());
         if (!vaultHub.isVaultConnected(_badDebtVault) || // vault is not connected to hub
-            !vaultHub.isVaultConnected(_vaultAcceptor) || // vault is not connected to hub
-            vaultHub.isPendingDisconnect(_badDebtVault) || // vault is disconnecting
-            vaultHub.isPendingDisconnect(_vaultAcceptor)) { // vault is disconnecting
+            !vaultHub.isVaultConnected(_vaultAcceptor)) { // vault is not connected to hub
             emit BadDebtSocializationFailed(_badDebtVault, _vaultAcceptor, _maxSharesToSocialize);
             return;
         }

--- a/et-vaults-factories-with-adapter-deployed-mainnet.json
+++ b/et-vaults-factories-with-adapter-deployed-mainnet.json
@@ -1,56 +1,56 @@
 {
-    "VaultsAdapter": {
-        "contract": "VaultsAdapter",
-        "address": "0xe2DE6d2DefF15588a71849c0429101F8ca9FB14D",
-        "constructorArgs": [
-            "0x18A1065c81b0Cc356F1b1C843ddd5E14e4AefffF",
-            "0xC1d0b3DE6792Bf6b4b37EccdcC24e45978Cfd2Eb",
-            "0xFE5986E06210aC1eCC1aDCafc0cc7f8D63B3F977",
-            100000000000000000
-        ]
-    },
-    "SetJailStatusInOperatorGrid": {
-        "contract": "SetJailStatusInOperatorGrid",
-        "address": "0x93F1DEE4473Ee9F42c8257C201e33a6Da30E5d67",
-        "constructorArgs": [
-            "0x18A1065c81b0Cc356F1b1C843ddd5E14e4AefffF",
-            "0xe2DE6d2DefF15588a71849c0429101F8ca9FB14D"
-        ]
-    },
-    "UpdateVaultsFeesInOperatorGrid": {
-        "contract": "UpdateVaultsFeesInOperatorGrid",
-        "address": "0x5C3bDFa3E7f312d8cf72F56F2b797b026f6B471c",
-        "constructorArgs": [
-            "0x18A1065c81b0Cc356F1b1C843ddd5E14e4AefffF",
-            "0xe2DE6d2DefF15588a71849c0429101F8ca9FB14D",
-            "0xC1d0b3DE6792Bf6b4b37EccdcC24e45978Cfd2Eb",
-            1000,
-            0,
-            100
-        ]
-    },
-    "ForceValidatorExitsInVaultHub": {
-        "contract": "ForceValidatorExitsInVaultHub",
-        "address": "0x6C968cD89CA358fbAf57B18e77a8973Fa869a6aA",
-        "constructorArgs": [
-            "0x18A1065c81b0Cc356F1b1C843ddd5E14e4AefffF",
-            "0xe2DE6d2DefF15588a71849c0429101F8ca9FB14D"
-        ]
-    },
-    "SocializeBadDebtInVaultHub": {
-        "contract": "SocializeBadDebtInVaultHub",
-        "address": "0x1dF50522A1D868C12bF71747Bb6F24A18Fe6d32C",
-        "constructorArgs": [
-            "0x18A1065c81b0Cc356F1b1C843ddd5E14e4AefffF",
-            "0xe2DE6d2DefF15588a71849c0429101F8ca9FB14D"
-        ]
-    },
-    "SetLiabilitySharesTargetInVaultHub": {
-        "contract": "SetLiabilitySharesTargetInVaultHub",
-        "address": "0x4E5Cc771c7b77f1417fa6BA9262d83C6CCc1e969",
-        "constructorArgs": [
-            "0x18A1065c81b0Cc356F1b1C843ddd5E14e4AefffF",
-            "0xe2DE6d2DefF15588a71849c0429101F8ca9FB14D"
-        ]
-    }
+  "VaultsAdapter": {
+    "contract": "VaultsAdapter",
+    "address": "0x28F9Ac198C4E0FA6A9Ad2c2f97CB38F1A3120f27",
+    "constructorArgs": [
+      "0x18A1065c81b0Cc356F1b1C843ddd5E14e4AefffF",
+      "0xC1d0b3DE6792Bf6b4b37EccdcC24e45978Cfd2Eb",
+      "0xFE5986E06210aC1eCC1aDCafc0cc7f8D63B3F977",
+      100000000000000000
+    ]
+  },
+  "SetJailStatusInOperatorGrid": {
+    "contract": "SetJailStatusInOperatorGrid",
+    "address": "0x6a4f33F05E7412A11100353724Bb6a152Cf0D305",
+    "constructorArgs": [
+      "0x18A1065c81b0Cc356F1b1C843ddd5E14e4AefffF",
+      "0x28F9Ac198C4E0FA6A9Ad2c2f97CB38F1A3120f27"
+    ]
+  },
+  "UpdateVaultsFeesInOperatorGrid": {
+    "contract": "UpdateVaultsFeesInOperatorGrid",
+    "address": "0xDfA0bc38113B6d53c2881573FD764CEEFf468610",
+    "constructorArgs": [
+      "0x18A1065c81b0Cc356F1b1C843ddd5E14e4AefffF",
+      "0x28F9Ac198C4E0FA6A9Ad2c2f97CB38F1A3120f27",
+      "0xC1d0b3DE6792Bf6b4b37EccdcC24e45978Cfd2Eb",
+      1000,
+      0,
+      100
+    ]
+  },
+  "ForceValidatorExitsInVaultHub": {
+    "contract": "ForceValidatorExitsInVaultHub",
+    "address": "0x6F5c0A5a824773E8f8285bC5aA59ea0Aab2A6400",
+    "constructorArgs": [
+      "0x18A1065c81b0Cc356F1b1C843ddd5E14e4AefffF",
+      "0x28F9Ac198C4E0FA6A9Ad2c2f97CB38F1A3120f27"
+    ]
+  },
+  "SocializeBadDebtInVaultHub": {
+    "contract": "SocializeBadDebtInVaultHub",
+    "address": "0xaf35A63a4114B7481589fDD9FDB3e35Fd65fAed7",
+    "constructorArgs": [
+      "0x18A1065c81b0Cc356F1b1C843ddd5E14e4AefffF",
+      "0x28F9Ac198C4E0FA6A9Ad2c2f97CB38F1A3120f27"
+    ]
+  },
+  "SetLiabilitySharesTargetInVaultHub": {
+    "contract": "SetLiabilitySharesTargetInVaultHub",
+    "address": "0x647DeE7bF33e44829e6430F7A08F63b3319694f0",
+    "constructorArgs": [
+      "0x18A1065c81b0Cc356F1b1C843ddd5E14e4AefffF",
+      "0x28F9Ac198C4E0FA6A9Ad2c2f97CB38F1A3120f27"
+    ]
+  }
 }

--- a/tests/evm_script_factories/test_socialize_bad_debt_in_vault_hub.py
+++ b/tests/evm_script_factories/test_socialize_bad_debt_in_vault_hub.py
@@ -1,5 +1,5 @@
 import pytest
-from brownie import reverts, SocializeBadDebtInVaultHub, VaultsAdapter, StakingVaultStub, ZERO_ADDRESS # type: ignore
+from brownie import interface, reverts, SocializeBadDebtInVaultHub, VaultsAdapter, StakingVaultStub, ZERO_ADDRESS # type: ignore
 
 from utils.evm_script import encode_call_script, encode_calldata
 
@@ -102,3 +102,51 @@ def test_decode_evm_script_call_data(accounts, socialize_bad_debt_factory):
         assert decoded_bad_debt_vaults[i] == bad_debt_vaults[i]
         assert decoded_vault_acceptors[i] == vault_acceptors[i]
         assert decoded_max_shares[i] == max_shares_to_socialize[i]
+
+def test_socialize_bad_debt_fails_when_bad_debt_vault_not_connected(owner, accounts, adapter, lido_locator_stub):
+    "Must emit BadDebtSocializationFailed when bad debt vault is not connected to hub"
+    vault_hub = interface.IVaultHub(lido_locator_stub.vaultHub())
+    bad_debt_vault = accounts[5]
+    vault_acceptor = accounts[6]
+    max_shares_to_socialize = 100
+
+    # Connect only vault_acceptor, not bad_debt_vault
+    vault_hub.connectVault(vault_acceptor, {"from": owner})
+
+    # Verify bad_debt_vault is NOT connected
+    assert vault_hub.isVaultConnected(bad_debt_vault) == False
+    # Verify vault_acceptor IS connected
+    assert vault_hub.isVaultConnected(vault_acceptor) == True
+
+    # Try to socialize bad debt - should fail
+    tx = adapter.socializeBadDebt(bad_debt_vault, vault_acceptor, max_shares_to_socialize, {"from": owner})
+
+    # Should emit BadDebtSocializationFailed event
+    assert "BadDebtSocializationFailed" in tx.events
+    assert tx.events["BadDebtSocializationFailed"]["badDebtVault"] == bad_debt_vault
+    assert tx.events["BadDebtSocializationFailed"]["vaultAcceptor"] == vault_acceptor
+    assert tx.events["BadDebtSocializationFailed"]["maxSharesToSocialize"] == max_shares_to_socialize
+
+def test_socialize_bad_debt_fails_when_vault_acceptor_not_connected(owner, accounts, adapter, lido_locator_stub):
+    "Must emit BadDebtSocializationFailed when vault acceptor is not connected to hub"
+    vault_hub = interface.IVaultHub(lido_locator_stub.vaultHub())
+    bad_debt_vault = accounts[5]
+    vault_acceptor = accounts[6]
+    max_shares_to_socialize = 100
+
+    # Connect only bad_debt_vault, not vault_acceptor
+    vault_hub.connectVault(bad_debt_vault, {"from": owner})
+
+    # Verify bad_debt_vault IS connected
+    assert vault_hub.isVaultConnected(bad_debt_vault) == True
+    # Verify vault_acceptor is NOT connected
+    assert vault_hub.isVaultConnected(vault_acceptor) == False
+
+    # Try to socialize bad debt - should fail
+    tx = adapter.socializeBadDebt(bad_debt_vault, vault_acceptor, max_shares_to_socialize, {"from": owner})
+
+    # Should emit BadDebtSocializationFailed event
+    assert "BadDebtSocializationFailed" in tx.events
+    assert tx.events["BadDebtSocializationFailed"]["badDebtVault"] == bad_debt_vault
+    assert tx.events["BadDebtSocializationFailed"]["vaultAcceptor"] == vault_acceptor
+    assert tx.events["BadDebtSocializationFailed"]["maxSharesToSocialize"] == max_shares_to_socialize


### PR DESCRIPTION
Fix [Redundant checks in Easy Track SocializeBadDebtInVaultHub factory](https://github.com/lidofinance/easy-track/issues/103) issue