### PR TITLE
Feature: add section about the stablecoin factories to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,12 @@ Script requires next ENV variables to be set:
 
 - `DEPLOYER` - address of the account that renounces roles
 
+### Stablecoin top-up factories
+
+`AllowedRecipientsBuilder`, `AllowedRecipientsFactory` and `AllowedTokensRegistry` were audited and deployed to mainnet from the [`feature/top-up-allowed-tokens`](https://github.com/lidofinance/easy-track/tree/feature/top-up-allowed-tokens) branch, which contains the audited commit [`52b1b1d`](https://github.com/lidofinance/easy-track/commit/52b1b1d99531a7aa46d8474bef56b157b83f318a). The branch is read-only and is not merged into `develop`. Deploy these contracts only from the tip of that branch so the bytecode matches the audited deployment. The copies under `contracts/payouts/multi-token` differ only in import paths and exist for tests.
+
+New top-up setups are created through the deployed builder with `scripts/payouts/multi_token/create_full_setup.py` or `create_single_recipient_setup.py` and require no contract compilation.
+
 ## Tests
 
 Set rpc url:

--- a/README.md
+++ b/README.md
@@ -163,9 +163,13 @@ Script requires next ENV variables to be set:
 
 ### Stablecoin top-up factories
 
-`AllowedRecipientsBuilder`, `AllowedRecipientsFactory` and `AllowedTokensRegistry` were audited and deployed to mainnet from the [`feature/top-up-allowed-tokens`](https://github.com/lidofinance/easy-track/tree/feature/top-up-allowed-tokens) branch, which contains the audited commit [`52b1b1d`](https://github.com/lidofinance/easy-track/commit/52b1b1d99531a7aa46d8474bef56b157b83f318a). The branch is read-only and is not merged into `develop`. Deploy these contracts only from the tip of that branch so the bytecode matches the audited deployment. The copies under `contracts/payouts/multi-token` differ only in import paths and exist for tests.
+Multi-token `AllowedRecipientsBuilder`, `AllowedRecipientsFactory` and `AllowedTokensRegistry` were audited and deployed to mainnet from the [`feature/top-up-allowed-tokens`](https://github.com/lidofinance/easy-track/tree/feature/top-up-allowed-tokens) branch, which contains the audited commit [`52b1b1d`](https://github.com/lidofinance/easy-track/commit/52b1b1d99531a7aa46d8474bef56b157b83f318a).
 
-New top-up setups are created through the deployed builder with `scripts/payouts/multi_token/create_full_setup.py` or `create_single_recipient_setup.py` and require no contract compilation.
+The branch is read-only and is not merged into `develop`. To keep the bytecode of these contracts identical to the audited version, deploy them only from the tip of that branch. The copies under `contracts/payouts/multi-token` differ only in import paths and exist for tests.
+
+The single-token `AllowedRecipientsBuilderSingleToken` and `AllowedRecipientsFactorySingleToken` can be deployed from `develop`, provided the optimizer is enabled in the Brownie configuration with 200 runs. This reproduces the bytecode of the existing deployments; the `SingleToken` suffix affects only the metadata hash.
+
+New top-up setups are created through the deployed builders with `create_full_setup.py` or `create_single_recipient_setup.py` under `scripts/payouts/single_token/` and `scripts/payouts/multi_token/`. They require no contract compilation and can be run from `develop`.
 
 ## Tests
 


### PR DESCRIPTION
The PR #58 containing the stablecoin top up factories setup is stale and has diverged severely from `develop` and a content merge is unsafe. PR #95 already brought the contracts into `develop` under `contracts/payouts/multi-token` by copy.

Instead of merging, the branch is kept as the deployment source:

- The `contracts/` tree is identical at the audited commit [`52b1b1d`](https://github.com/lidofinance/easy-track/pull/58/changes/52b1b1d99531a7aa46d8474bef56b157b83f318a) and at the branch tip [`95558ad`](https://github.com/lidofinance/easy-track/pull/58/changes/95558ad0d7d48f02d0a3cd127c32db529ea5c7ca), so no contract changed after the audit.
- The branch compiles with the optimizer settings used for the mainnet deployment. `develop` disables the optimizer in `brownie-config.yaml`, so a deployment from `develop` would not match the audited bytecode.
- Creating new top-up setups goes through the deployed builder and needs no compilation. Only redeployments of the builder/factory setup might be needed.

This PR adds a mention about the stablecoin factories builder/factory/tokenlist deployments to the README for further reference. 

### Further actions

- [ ] Lock `feature/top-up-allowed-tokens` as read-only
- [ ] Close #58 with a link to this PR and ensure the branch is preserved.